### PR TITLE
Add a name argument similar to threads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@
 *swp
 .eggs
 build/
-
+*.py[co]
+[.]venv/ 

--- a/src/extrainterpreters/base_interpreter.py
+++ b/src/extrainterpreters/base_interpreter.py
@@ -14,10 +14,11 @@ _TTL = 0.01
 
 class BaseInterpreter:
 
-    def __init__(self):
+    def __init__(self, name=None):
         # .intno and .id are both set to the interpreter id,
         # but .intno is set to None when the interpreter is closed.
         self.intno = self.id = None
+        self.name = name
         self.lock = threading.RLock()
 
     def start(self):
@@ -25,6 +26,7 @@ class BaseInterpreter:
             raise RuntimeError("Interpreter already started")
         with self.lock:
             self.intno = self.id = interpreters.create()
+            self.name = self.name or f"Subinterpreter #{self.intno}"
             running_interpreters[self.intno] = self
             self.thread = None
             self._create_channel()
@@ -44,11 +46,11 @@ class BaseInterpreter:
             try:
                 while time.monotonic() - self._started_at < _TTL:
                     # subinterpreters need sometime to stabilize.
-                    # shutting then imediatelly may lead to a segfault.
+                    # shutting then immediately may lead to a segfault.
                     time.sleep(0.002)
                 if interpreters.is_running(self.intno):
                     # TBD: close on "at exit"
-                    # # but really, just enduser code running with "run_string΅ on other thread should
+                    # # but really, just end user code running with "run_string" on other thread should
                     # leave the sub-interpreter on this state.
                     return
                 interpreters.destroy(self.intno)

--- a/src/extrainterpreters/piped_interpreter.py
+++ b/src/extrainterpreters/piped_interpreter.py
@@ -41,8 +41,8 @@ class FuncData(StructBase):
 def _dispatcher(pipe, buffer):
     """the core running function in a PipedInterpreter
 
-    This is responsible for watching comunications with the parent
-    interpreter, dispathing execution, and place the return values
+    This is responsible for watching communications with the parent
+    interpreter, dispatching execution, and place the return values
     """
 
     while True:
@@ -113,6 +113,3 @@ class PipedInterpreter(_BufferedInterpreter):
             self.pipe.read(timeout=None)
             self.pipe.close()
         super()._close_channel()
-
-
-

--- a/src/extrainterpreters/simple_interpreter.py
+++ b/src/extrainterpreters/simple_interpreter.py
@@ -114,9 +114,9 @@ class SimpleInterpreter(_BufferedInterpreter):
     This implementation uses a memory area  (by default of 10MB), to send pickled objects back and fort at fixed offsets.
     """
 
-    def __init__(self, target=None, args=(), kwargs=None):
+    def __init__(self, name=None, target=None, args=(), kwargs=None):
         kwargs = kwargs or {}
-        super().__init__()
+        super().__init__(name=name)
         self.target = target
         self._args = args
         self._kwargs = kwargs


### PR DESCRIPTION
It's handy to set a name field on the interpreter (the Pooled Worker/Executor class will use this later)